### PR TITLE
fix: allow building

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -11,6 +11,6 @@
 last 1 Chrome version
 last 1 Firefox version
 last 2 Edge major versions
-last 2 Safari major versions
+# last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR


### PR DESCRIPTION
Angular 13.1 seems to be broken, and the fix has been meregd but not released yet. Fix: https://github.com/angular/angular-cli/issues/22606